### PR TITLE
feat: add commit status endpoints

### DIFF
--- a/apps/api/workspaces/commits/[commitId]/index.ts
+++ b/apps/api/workspaces/commits/[commitId]/index.ts
@@ -1,0 +1,27 @@
+import { EaCRuntimeHandlers } from '@fathym/eac/runtime/pipelines';
+import { loadEaCStewardSvc } from '@fathym/eac/steward/clients';
+import { OpenIndustrialAPIState } from '../../../../../src/state/OpenIndustrialAPIState.ts';
+
+export default {
+  async GET(_req, ctx) {
+    try {
+      const commitId = ctx.Params.commitId;
+
+      if (!commitId || !ctx.State.EaCJWT) {
+        return new Response('Commit not found.', { status: 404 });
+      }
+
+      const eacSvc = await loadEaCStewardSvc(ctx.State.EaCJWT);
+
+      const status = await eacSvc.Status.Get(commitId);
+
+      if (!status) {
+        return new Response('Commit not found.', { status: 404 });
+      }
+
+      return Response.json(status);
+    } catch {
+      return new Response('Failed to retrieve commit status.', { status: 500 });
+    }
+  },
+} as EaCRuntimeHandlers<OpenIndustrialAPIState>;

--- a/apps/api/workspaces/commits/index.ts
+++ b/apps/api/workspaces/commits/index.ts
@@ -1,0 +1,21 @@
+import { EaCRuntimeHandlers } from '@fathym/eac/runtime/pipelines';
+import { loadEaCStewardSvc } from '@fathym/eac/steward/clients';
+import { OpenIndustrialAPIState } from '../../../../src/state/OpenIndustrialAPIState.ts';
+
+export default {
+  async GET(_req, ctx) {
+    try {
+      if (!ctx.State.EaCJWT) {
+        return new Response('Missing EaC authentication.', { status: 500 });
+      }
+
+      const eacSvc = await loadEaCStewardSvc(ctx.State.EaCJWT);
+
+      const stati = await eacSvc.Status.ListStati();
+
+      return Response.json(stati);
+    } catch {
+      return new Response('Failed to retrieve commit statuses.', { status: 500 });
+    }
+  },
+} as EaCRuntimeHandlers<OpenIndustrialAPIState>;


### PR DESCRIPTION
## Summary
- add GET endpoint to list commit statuses via EaC steward service
- add per-commit status endpoint returning 404 when missing

## Testing
- `deno fmt apps/api/workspaces/commits/index.ts apps/api/workspaces/commits/[commitId]/index.ts`
- `deno lint apps/api/workspaces/commits/index.ts apps/api/workspaces/commits/[commitId]/index.ts`
- `NODE_TLS_REJECT_UNAUTHORIZED=0 deno task test` *(fails: invalid peer certificate for npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_689b679e07fc8326a7e7f2a2f525e499